### PR TITLE
[CBE-740] Update rswag for rails 7.2

### DIFF
--- a/lib/open_api/specs/example_methods.rb
+++ b/lib/open_api/specs/example_methods.rb
@@ -8,23 +8,21 @@ module OpenApi
 
       # Process the request with RSwag, and add examples
       def process_example(config, example)
-        Rails.application.deprecators.silence do
-          submit_request(example.metadata)
+        submit_request(example.metadata)
 
-          # HACK, solves issue with [OpenStruct.new] slipping through
-          if respond_to?(:last_response) && last_response.status == 204 &&
-               last_response.instance_variable_get(:@body).first.is_a?(OpenStruct)
-            body = last_response.instance_variable_get(:@body).first.to_h
-            body = body.blank? ? '' : OpenStruct.new(body)
-            last_response.body = [body]
-          end
-
-          ::Rswag::Specs::RequestValidator.new.validate!(example.metadata, request)
-          ::Rswag::Specs::ResponseValidator.new.validate!(example.metadata, response)
-
-          add_request_examples(example)
-          add_response_examples(example)
+        # HACK, solves issue with [OpenStruct.new] slipping through
+        if respond_to?(:last_response) && last_response.status == 204 &&
+             last_response.instance_variable_get(:@body).first.is_a?(OpenStruct)
+          body = last_response.instance_variable_get(:@body).first.to_h
+          body = body.blank? ? '' : OpenStruct.new(body)
+          last_response.body = [body]
         end
+
+        ::Rswag::Specs::RequestValidator.new.validate!(example.metadata, request)
+        ::Rswag::Specs::ResponseValidator.new.validate!(example.metadata, response)
+
+        add_request_examples(example)
+        add_response_examples(example)
 
         puts_request_response if config[:focus]
       rescue StandardError => e

--- a/lib/open_api/specs/formatter.rb
+++ b/lib/open_api/specs/formatter.rb
@@ -34,7 +34,7 @@ module OpenApi
         return if metadata[:document] == false
         return unless metadata.key?(:response)
 
-        swagger_doc = Rails.application.deprecators.silence { @config.get_swagger_doc(metadata[:swagger_doc]) }
+        swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
 
         unless doc_version(swagger_doc).start_with?('2')
           # This is called multiple times per file!

--- a/lib/open_api/specs/rswag.rb
+++ b/lib/open_api/specs/rswag.rb
@@ -100,7 +100,7 @@ module Rswag
       def validate!(metadata, request)
         return if metadata[:response][:code] == '400' # expected to fail
 
-        swagger_doc = Rails.application.deprecators.silence { @config.get_swagger_doc(metadata[:swagger_doc]) }
+        swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
 
         validate_headers!(metadata, request[:headers])
         validate_body!(metadata, swagger_doc, request.body.read)
@@ -205,6 +205,45 @@ module Rswag
             # END HACK
 
           end
+        end
+      end
+    end
+
+    class Configuration
+      # Use new ActiveSupport syntax for silencing deprecations (needed for Rails 7.1+ in core), can be removed
+      # if/when we bump up rswag versions (current is 2.12) and the warnings are no longer relevant
+
+      def deprecator
+        @deprecator ||= ActiveSupport::Deprecation.new
+      end
+
+      def swagger_docs
+        deprecator.silence do
+          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_specs" in v3.0')
+          @swagger_docs ||= begin
+            if @rspec_config.swagger_docs.nil? || @rspec_config.swagger_docs.empty?
+              raise ConfigurationError, 'No swagger_docs defined. See swagger_helper.rb'
+            end
+
+            @rspec_config.swagger_docs
+          end
+        end
+      end
+
+      def get_swagger_doc(name)
+        deprecator.silence do
+          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "get_openapi_spec" in v3.0')
+          return swagger_docs.values.first if name.nil?
+          raise ConfigurationError, "Unknown swagger_doc '#{name}'" unless swagger_docs[name]
+
+          swagger_docs[name]
+        end
+      end
+
+      def swagger_strict_schema_validation
+        deprecator.silence do
+          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_strict_schema_validation" in v3.0')
+          @swagger_strict_schema_validation ||= (@rspec_config.swagger_strict_schema_validation || false)
         end
       end
     end


### PR DESCRIPTION
This PR addresses deprecation warnings that were surfacing in Core as part of the Rails 7.1 migration, in a way that is compatible with public-api's use case (not a Rails app, fewer convenience classes to call upon). These changes can be removed when we're ready address the warnings highlighted and bump up to the next version of rswag.

Related JIRA:
[CBE-740](https://cutover.atlassian.net/browse/CBE-740)
[CBE-766](https://cutover.atlassian.net/browse/CBE-766)

Verification:
Passing public-api build: https://github.com/gocutover/public-api/pull/808

[CBE-740]: https://cutover.atlassian.net/browse/CBE-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBE-766]: https://cutover.atlassian.net/browse/CBE-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ