### PR TITLE
[CBE-890] [CBE-781]Rails 7.2 Update

### DIFF
--- a/lib/open_api/specs.rb
+++ b/lib/open_api/specs.rb
@@ -25,7 +25,7 @@ module OpenApi
         config.include ExampleMethods
 
         config.add_setting :open_api_example_cleaner
-        config.swagger_dry_run = false
+        config.rswag_dry_run = false
       end
     end
   end

--- a/lib/open_api/specs/formatter.rb
+++ b/lib/open_api/specs/formatter.rb
@@ -34,7 +34,7 @@ module OpenApi
         return if metadata[:document] == false
         return unless metadata.key?(:response)
 
-        swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
+        swagger_doc = @config.get_openapi_spec(metadata[:swagger_doc])
 
         unless doc_version(swagger_doc).start_with?('2')
           # This is called multiple times per file!
@@ -50,7 +50,7 @@ module OpenApi
       end
 
       def stop(_notification = nil)
-        @config.swagger_docs.each do |url_path, doc|
+        @config.openapi_specs.each do |url_path, doc|
           unless doc_version(doc).start_with?('2')
             doc[:paths]&.each_pair do |_k, v|
               v.each_pair do |_verb, value|

--- a/lib/open_api/specs/formatter.rb
+++ b/lib/open_api/specs/formatter.rb
@@ -89,7 +89,7 @@ module OpenApi
             end
           end
 
-          file_path = File.join(@config.swagger_root, url_path)
+          file_path = File.join(@config.openapi_root, url_path)
           dirname = File.dirname(file_path)
           FileUtils.mkdir_p dirname unless File.exist?(dirname)
 
@@ -109,7 +109,7 @@ module OpenApi
       private
 
       def pretty_generate(doc)
-        if @config.swagger_format == :yaml
+        if @config.openapi_format == :yaml
           clean_doc = yaml_prepare(doc)
           YAML.dump(clean_doc)
         else # config errors are thrown in 'def swagger_format', no throw needed here

--- a/lib/open_api/specs/rswag.rb
+++ b/lib/open_api/specs/rswag.rb
@@ -100,7 +100,7 @@ module Rswag
       def validate!(metadata, request)
         return if metadata[:response][:code] == '400' # expected to fail
 
-        swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
+        swagger_doc = @config.get_openapi_spec(metadata[:swagger_doc])
 
         validate_headers!(metadata, request[:headers])
         validate_body!(metadata, swagger_doc, request.body.read)
@@ -205,45 +205,6 @@ module Rswag
             # END HACK
 
           end
-        end
-      end
-    end
-
-    class Configuration
-      # Use new ActiveSupport syntax for silencing deprecations (needed for Rails 7.1+ in core), can be removed
-      # if/when we bump up rswag versions (current is 2.12) and the warnings are no longer relevant
-
-      def deprecator
-        @deprecator ||= ActiveSupport::Deprecation.new
-      end
-
-      def swagger_docs
-        deprecator.silence do
-          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_specs" in v3.0')
-          @swagger_docs ||= begin
-            if @rspec_config.swagger_docs.nil? || @rspec_config.swagger_docs.empty?
-              raise ConfigurationError, 'No swagger_docs defined. See swagger_helper.rb'
-            end
-
-            @rspec_config.swagger_docs
-          end
-        end
-      end
-
-      def get_swagger_doc(name)
-        deprecator.silence do
-          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "get_openapi_spec" in v3.0')
-          return swagger_docs.values.first if name.nil?
-          raise ConfigurationError, "Unknown swagger_doc '#{name}'" unless swagger_docs[name]
-
-          swagger_docs[name]
-        end
-      end
-
-      def swagger_strict_schema_validation
-        deprecator.silence do
-          deprecator.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_strict_schema_validation" in v3.0')
-          @swagger_strict_schema_validation ||= (@rspec_config.swagger_strict_schema_validation || false)
         end
       end
     end

--- a/open_api-specs.gemspec
+++ b/open_api-specs.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rspec', '>= 3.0.0'
   spec.add_dependency 'open_api-schema_validator', '~> 0.2.0'
-  spec.add_dependency 'rswag', '2.12.0'
+  spec.add_dependency 'rswag', '2.14.0'
 end

--- a/open_api-specs.gemspec
+++ b/open_api-specs.gemspec
@@ -13,5 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rspec', '>= 3.0.0'
   spec.add_dependency 'open_api-schema_validator', '~> 0.2.0'
-  spec.add_dependency 'rswag', '2.14.0'
+  spec.add_dependency 'rswag-api', '2.14.0'
+  spec.add_dependency 'rswag-specs', '2.14.0'
 end


### PR DESCRIPTION
This PR updates our rswag-related dependencies by two point releases, which is a necessary update for the core Rails 7.2 upgrade. In addition, it:
- removes a temporary patch
- updates various deprecated methods to be in step with the current API, as they caused breaking behavior with the version bump
- removes rswag-ui from the dependency tree

Related Jira:
[CBE-890](https://cutover.atlassian.net/browse/CBE-890)

[CBE-890]: https://cutover.atlassian.net/browse/CBE-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ