### PR TITLE
[CBE-1109] Rails 8.0/Rails 8.1 Upgrade Branch

### DIFF
--- a/lib/open_api/specs/rswag.rb
+++ b/lib/open_api/specs/rswag.rb
@@ -102,11 +102,22 @@ module Rswag
 
         swagger_doc = @config.get_openapi_spec(metadata[:swagger_doc])
 
-        validate_headers!(metadata, request[:headers])
-        validate_body!(metadata, swagger_doc, request.body.read)
+        validate_headers!(metadata, request_headers(request))
+        validate_body!(metadata, swagger_doc, request.raw_post)
       end
 
       private
+
+      # Check if request responds to ActionDispatch::Request (Rails 8+/rswag >=2.16), fall back
+      # to old behavior if customer is still on Rails 7. Can be removed/amended after
+      # all clients are migrated
+      def request_headers(request)
+        if request.respond_to?(:headers)
+          request.headers
+        elsif request.respond_to?(:[])
+          request[:headers]
+        end
+      end
 
       def validate_headers!(metadata, headers)
         return # @todo implement

--- a/lib/open_api/specs/rswag.rb
+++ b/lib/open_api/specs/rswag.rb
@@ -103,7 +103,7 @@ module Rswag
         swagger_doc = @config.get_openapi_spec(metadata[:swagger_doc])
 
         validate_headers!(metadata, request_headers(request))
-        validate_body!(metadata, swagger_doc, request.raw_post)
+        validate_body!(metadata, swagger_doc, request_body(request))
       end
 
       private
@@ -116,6 +116,16 @@ module Rswag
           request.headers
         elsif request.respond_to?(:[])
           request[:headers]
+        end
+      end
+
+      # ActionDispatch::Request (Rails) exposes #raw_post; a plain Rack::Request (used by
+      # non-Rails Rack apps) does not, so fall back to reading the body directly.
+      def request_body(request)
+        if request.respond_to?(:raw_post)
+          request.raw_post
+        else
+          request.body.read
         end
       end
 

--- a/open_api-specs.gemspec
+++ b/open_api-specs.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rspec', '>= 3.0.0'
   spec.add_dependency 'open_api-schema_validator', '~> 0.2.0'
-  spec.add_dependency 'rswag-api', '2.16.0'
-  spec.add_dependency 'rswag-specs', '2.16.0'
+  spec.add_dependency 'rspec', '>= 3.0.0'
+  spec.add_dependency 'rswag-api', '~> 2.17'
+  spec.add_dependency 'rswag-specs', '~> 2.17'
 end

--- a/open_api-specs.gemspec
+++ b/open_api-specs.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rspec', '>= 3.0.0'
   spec.add_dependency 'open_api-schema_validator', '~> 0.2.0'
-  spec.add_dependency 'rswag-api', '2.14.0'
-  spec.add_dependency 'rswag-specs', '2.14.0'
+  spec.add_dependency 'rswag-api', '2.16.0'
+  spec.add_dependency 'rswag-specs', '2.16.0'
 end


### PR DESCRIPTION
This PR updates the rswag-api version for the Rails 8 upgrade.

Related tickets:
[CBE-1109](https://cutover.atlassian.net/browse/CBE-1109)
[CBE-1156](https://cutover.atlassian.net/browse/CBE-1156)
[CBE-1172](https://cutover.atlassian.net/browse/CBE-1172)

[CBE-1109]: https://cutover.atlassian.net/browse/CBE-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBE-1156]: https://cutover.atlassian.net/browse/CBE-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CBE-1172]: https://cutover.atlassian.net/browse/CBE-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ